### PR TITLE
labscript state machine modification

### DIFF
--- a/labscript_devices/NI_DAQmx/blacs_workers.py
+++ b/labscript_devices/NI_DAQmx/blacs_workers.py
@@ -135,6 +135,8 @@ class NI_DAQmxOutputWorker(Worker):
         # TODO: return coerced/quantised values
         return {}
 
+    # TODO:OPT: Not opening the file in the experiment queue significantly speeds up the file query time
+    # need to figure out why...
     def get_output_tables(self, h5file, device_name):
         """Return the AO and DO tables rom the file, or None if they do not exist."""
         with h5py.File(h5file, 'r') as hdf5_file:

--- a/labscript_devices/NI_DAQmx/blacs_workers.py
+++ b/labscript_devices/NI_DAQmx/blacs_workers.py
@@ -354,11 +354,9 @@ class NI_DAQmxOutputWorker(Worker):
             final_values[self.wait_timeout_connection] = self.wait_timeout_rearm_value
 
         return final_values
-
-    def transition_to_manual(self, abort=False):
-        # Stop output tasks and call program_manual. Only call StopTask if not aborting.
-        # Otherwise results in an error if output was incomplete. If aborting, call
-        # ClearTask only.
+    
+    def post_experiment(self):
+        # Stop output tasks
         npts = uInt64()
         samples = uInt64()
         tasks = []
@@ -370,23 +368,22 @@ class NI_DAQmxOutputWorker(Worker):
             self.DO_task = None
 
         for task, static, name in tasks:
-            if not abort:
-                if not static:
-                    try:
-                        # Wait for task completion with a 1 second timeout:
-                        task.WaitUntilTaskDone(1)
-                    finally:
-                        # Log where we were up to in sample generation, regardless of
-                        # whether the above succeeded:
-                        task.GetWriteCurrWritePos(npts)
-                        task.GetWriteTotalSampPerChanGenerated(samples)
-                        # Detect -1 even though they're supposed to be unsigned ints, -1
-                        # seems to indicate the task was not started:
-                        current = samples.value if samples.value != 2 ** 64 - 1 else -1
-                        total = npts.value if npts.value != 2 ** 64 - 1 else -1
-                        msg = 'Stopping %s at sample %d of %d'
-                        self.logger.info(msg, name, current, total)
-                task.StopTask()
+            if not static:
+                try:
+                    # Wait for task completion with a 1 second timeout:
+                    task.WaitUntilTaskDone(1)
+                finally:
+                    # Log where we were up to in sample generation, regardless of
+                    # whether the above succeeded:
+                    task.GetWriteCurrWritePos(npts)
+                    task.GetWriteTotalSampPerChanGenerated(samples)
+                    # Detect -1 even though they're supposed to be unsigned ints, -1
+                    # seems to indicate the task was not started:
+                    current = samples.value if samples.value != 2 ** 64 - 1 else -1
+                    total = npts.value if npts.value != 2 ** 64 - 1 else -1
+                    msg = 'Stopping %s at sample %d of %d'
+                    self.logger.info(msg, name, current, total)
+            task.StopTask()
             task.ClearTask()
 
         # Remove the mirroring of the clock terminal, if applicable:
@@ -395,6 +392,26 @@ class NI_DAQmxOutputWorker(Worker):
         # Remove connections between other terminals, if applicable:
         self.set_connected_terminals_connected(False)
 
+        return True
+    
+    def transition_to_manual(self, abort=False):
+        # If aborting, stop output tasks. And program device to manual
+        if abort:
+            # We did not call transition_to_manual from post_experiment, stop output 
+            # task accordingly
+            npts = uInt64()
+            samples = uInt64()
+            tasks = []
+            if self.AO_task is not None:
+                tasks.append([self.AO_task, self.static_AO or self.AO_all_zero, 'AO'])
+                self.AO_task = None
+            if self.DO_task is not None:
+                tasks.append([self.DO_task, self.static_DO or self.DO_all_zero, 'DO'])
+                self.DO_task = None
+
+            for task, _, _ in tasks:
+                task.ClearTask()
+        
         # Set up manual mode tasks again:
         self.start_manual_mode_tasks()
         if abort:
@@ -433,13 +450,14 @@ class NI_DAQmxAcquisitionWorker(Worker):
         # and disable inputs in manual mode, and adjust the rate:
         self.manual_mode_chans = self.AI_chans
         self.manual_mode_rate = 1000
+        self.manual_mode_task = False
 
         # An event for knowing when the wait durations are known, so that we may use
         # them to chunk up acquisition data:
         self.wait_durations_analysed = Event('wait_durations_analysed')
 
         # Start task for manual mode
-        self.start_task(self.manual_mode_chans, self.manual_mode_rate)
+        self.manual_mode_task = self.start_task(self.manual_mode_chans, self.manual_mode_rate)
 
     def shutdown(self):
         if self.task is not None:
@@ -536,6 +554,8 @@ class NI_DAQmxAcquisitionWorker(Worker):
 
         self.task.StartTask()
 
+        return True
+
     def stop_task(self):
         with self.tasklock:
             if self.task is None:
@@ -570,32 +590,24 @@ class NI_DAQmxAcquisitionWorker(Worker):
             # delay is defined in sample clock ticks, calculate in sec and save for later
             self.AI_start_delay = self.AI_start_delay_ticks*self.buffered_rate
         self.acquired_data = []
-        # Stop the manual mode task and start the buffered mode task:
-        self.stop_task()
+        # Stop the manual mode task if it is running and start the buffered mode task:
+        if self.manual_mode_task:
+            self.stop_task()
         self.buffered_mode = True
         self.start_task(self.buffered_chans, self.buffered_rate)
         return {}
 
-    def transition_to_manual(self, abort=False):
-        self.logger.debug('transition_to_manual')
-        #  If we were doing buffered mode acquisition, stop the buffered mode task and
-        # start the manual mode task. We might not have been doing buffered mode
-        # acquisition if abort() was called when we are not in buffered mode, or if
+    def post_experiment(self):
+        self.logger.debug('post_experiment processing')
+        # If we were doing buffered mode acquisition, stop the buffered mode task. 
+        # We might not have been doing buffered mode acquisition if
         # there were no acuisitions this shot.
         if not self.buffered_mode:
             return True
         if self.buffered_chans is not None:
             self.stop_task()
         self.buffered_mode = False
-        self.logger.info('transitioning to manual mode, task stopped')
-        self.start_task(self.manual_mode_chans, self.manual_mode_rate)
-
-        if abort:
-            self.acquired_data = None
-            self.buffered_chans = None
-            self.h5_file = None
-            self.buffered_rate = None
-            return True
+        self.logger.info('processing acquired data, task stopped')
 
         with h5py.File(self.h5_file, 'a') as hdf5_file:
             data_group = hdf5_file['data']
@@ -622,6 +634,30 @@ class NI_DAQmxAcquisitionWorker(Worker):
         else:
             msg = 'No acquisitions in this shot.'
         self.logger.info(msg)
+
+        self.manual_mode_task = False
+
+        return True
+
+    def transition_to_manual(self, abort=False):
+        self.logger.debug('transition_to_manual')
+        # Handle abort calls, and start manual mode task 
+        if abort:
+            if not self.buffered_mode:
+                return True
+            if self.buffered_chans is not None:
+                self.stop_task()
+            self.buffered_mode = False
+            self.logger.info('transitioning to manual mode, task stopped')
+            self.manual_mode_task = self.start_task(self.manual_mode_chans, self.manual_mode_rate)
+            self.manual_mode_task
+            self.acquired_data = None
+            self.buffered_chans = None
+            self.h5_file = None
+            self.buffered_rate = None
+        else:
+            self.logger.info('transitioning to manual mode')
+            self.manual_mode_task = self.start_task(self.manual_mode_chans, self.manual_mode_rate)
 
         return True
 
@@ -928,10 +964,11 @@ class NI_DAQmxWaitMonitorWorker(Worker):
 
         return {}
 
-    def transition_to_manual(self, abort=False):
-        self.logger.debug('transition_to_manual')
-        self.stop_tasks(abort)
-        if not abort and self.wait_table is not None:
+    def post_experiment(self):
+        self.logger.debug('post_experiment processing')
+        self.stop_tasks(False)
+        
+        if self.wait_table is not None:
             # Let's work out how long the waits were. The absolute times of each edge on
             # the wait monitor were:
             edge_times = np.cumsum(self.semiperiods)
@@ -971,6 +1008,14 @@ class NI_DAQmxWaitMonitorWorker(Worker):
 
         self.h5_file = None
         self.semiperiods = None
+        return True
+    
+    def transition_to_manual(self, abort=False):
+        self.logger.debug('transition_to_manual')
+        if (abort):
+            self.stop_tasks(abort)
+            self.h5_file = None
+            self.semiperiods = None
         return True
 
     def abort_buffered(self):

--- a/labscript_devices/PulseBlaster_No_DDS.py
+++ b/labscript_devices/PulseBlaster_No_DDS.py
@@ -432,7 +432,7 @@ class PulseblasterNoDDSWorker(Worker):
             time_based_shot_over = None
         return pb_read_status(), self.waits_pending, time_based_shot_over
         
-    def transition_to_manual(self):
+    def post_experiment(self):
         status, waits_pending, time_based_shot_over = self.check_status()
         
         if self.programming_scheme == 'pb_start/BRANCH':
@@ -453,6 +453,9 @@ class PulseblasterNoDDSWorker(Worker):
             return True
         else:
             return False
+    
+    def transition_to_manual(self):
+        return True
      
     def abort_buffered(self):
         # Stop the execution

--- a/labscript_devices/PulseBlaster_No_DDS.py
+++ b/labscript_devices/PulseBlaster_No_DDS.py
@@ -235,7 +235,7 @@ class Pulseblaster_No_DDS_Tab(DeviceTab):
         the run is over"""
         self.statemachine_timeout_remove(self.status_monitor)
         self.start()
-        self.statemachine_timeout_add(15,self.status_monitor,notify_queue)
+        self.statemachine_timeout_add(1,self.status_monitor,notify_queue)
 
 
 class PulseblasterNoDDSWorker(Worker):

--- a/labscript_devices/PulseBlaster_No_DDS.py
+++ b/labscript_devices/PulseBlaster_No_DDS.py
@@ -235,7 +235,7 @@ class Pulseblaster_No_DDS_Tab(DeviceTab):
         the run is over"""
         self.statemachine_timeout_remove(self.status_monitor)
         self.start()
-        self.statemachine_timeout_add(100,self.status_monitor,notify_queue)
+        self.statemachine_timeout_add(15,self.status_monitor,notify_queue)
 
 
 class PulseblasterNoDDSWorker(Worker):

--- a/labscript_devices/PulseBlaster_No_DDS.py
+++ b/labscript_devices/PulseBlaster_No_DDS.py
@@ -17,6 +17,7 @@ from labscript import PseudoclockDevice, config
 
 import numpy as np
 
+from qtutils import qtlock
 
 class PulseBlaster_No_DDS(PulseBlaster):
 
@@ -199,9 +200,9 @@ class Pulseblaster_No_DDS_Tab(DeviceTab):
                 icon = QtGui.QIcon(':/qtutils/fugue/tick')
             else:
                 icon = QtGui.QIcon(':/qtutils/fugue/cross')
-            
-            pixmap = icon.pixmap(QtCore.QSize(16, 16))
-            self.status_widgets[state].setPixmap(pixmap)
+            with qtlock:
+                pixmap = icon.pixmap(QtCore.QSize(16, 16))
+                self.status_widgets[state].setPixmap(pixmap)
         
     
     @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)  

--- a/labscript_devices/PulseBlaster_No_DDS.py
+++ b/labscript_devices/PulseBlaster_No_DDS.py
@@ -173,7 +173,10 @@ class Pulseblaster_No_DDS_Tab(DeviceTab):
         # When called with a queue, this function writes to the queue
         # when the pulseblaster is waiting. This indicates the end of
         # an experimental run.
-        self.status, waits_pending, time_based_shot_over = yield(self.queue_work(self._primary_worker,'check_status'))
+        tasks = []
+        tasks.append(self.queue_work(self._primary_worker,'check_status'))
+        raw_results = yield(tasks, False)
+        self.status, waits_pending, time_based_shot_over = raw_results[0]
         
         if self.programming_scheme == 'pb_start/BRANCH':
             done_condition = self.status['waiting']
@@ -207,17 +210,23 @@ class Pulseblaster_No_DDS_Tab(DeviceTab):
     
     @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)  
     def start(self,widget=None):
-        yield(self.queue_work(self._primary_worker,'start_run'))
+        tasks = []
+        tasks.append(self.queue_work(self._primary_worker,'start_run'))
+        yield(tasks, False)
         self.status_monitor()
         
     @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)  
     def stop(self,widget=None):
-        yield(self.queue_work(self._primary_worker,'pb_stop'))
+        tasks = []
+        tasks.append(self.queue_work(self._primary_worker,'pb_stop'))
+        yield(tasks, False)
         self.status_monitor()
         
     @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)  
     def reset(self,widget=None):
-        yield(self.queue_work(self._primary_worker,'pb_reset'))
+        tasks = []
+        tasks.append(self.queue_work(self._primary_worker,'pb_reset'))
+        yield(tasks, False)
         self.status_monitor()
     
     @define_state(MODE_BUFFERED,True)  


### PR DESCRIPTION
## Background
The `labscript-devices` part of [labscript state machine modification and optimization #1](https://github.com/shafinulh/blacs/pull/1).

## Changes
- Adds the `post_experiment` state implementation to the `NI_DAQmx` device workers and the `PulseBlasterUSB-No DDS`.
- Schedules the `PulseBlasterUSB-No DDS` (master pseudoclock) `status_monitor` every 1ms to ensure the experiment is stopped on time 