### PR TITLE
read NI acquired data buffer more frequently for shorter experiments

### DIFF
--- a/labscript_devices/NI_DAQmx/blacs_workers.py
+++ b/labscript_devices/NI_DAQmx/blacs_workers.py
@@ -431,7 +431,7 @@ class NI_DAQmxOutputWorker(Worker):
 
 class NI_DAQmxAcquisitionWorker(Worker):
     MAX_READ_INTERVAL = 0.2
-    MAX_READ_PTS = 10000
+    MAX_READ_PTS = 1000
 
     def init(self):
         # Prevent interference between the read callback and the shutdown code:


### PR DESCRIPTION
With short (20ms) shot lengths, the NI data acquisition sometimes fails having not collected any data. If the NI DAQmx calls the callback after fewer  `MAX_READ_PTS` the device does not seem to skip the data collection. 

**Note:** This is concerning as the acquired data should always be collected if not during the shot execution, at the end of the shot. This current fix is a hack and should be looked into solving a proper solution. 