### PR TITLE
check_remote_values upon initialization rather than sending random va…

### DIFF
--- a/labscript_devices/RemoteControl/blacs_tabs.py
+++ b/labscript_devices/RemoteControl/blacs_tabs.py
@@ -204,6 +204,8 @@ class RemoteControlTab(DeviceTab):
         )
         self.primary_worker = "main_worker"
 
+        self._can_check_remote_values = True
+
         if self.mock:
             self.reqrep_connected = True
             self.manual_remote_polling()

--- a/labscript_devices/RemoteControl/blacs_workers.py
+++ b/labscript_devices/RemoteControl/blacs_workers.py
@@ -70,7 +70,7 @@ class RemoteCommunication:
 
         self.logger.debug(f"TRYING TO SET UP CONNECTION, tcp://{self.host}:{self.port}")
         
-        message = {"action": "HELLO", "connection": None}
+        message = {"action": "HELLO", "connection": ""}
         
         response = self.send_request(message)
         if response is None:
@@ -206,7 +206,7 @@ class RemoteControlWorker(Worker):
             dict: A dictionary of remote ouput values.
         """
         if not self.remote_comms.connected:
-            return
+            return False
         
         def check_output_values():
             if len(self.child_output_connections) == 0:


### PR DESCRIPTION
Problem: incorrect values were being sent to the remote devices upon initialization. 
Fix: set `self._can_check_remote_values` upon initialization which appropriately calls `check_remote_values` instead of `program_device`. 
- if the device is disconnected upon initialization, the `check_remote_values` worker function now returns False to indicate the device is not connected and `check_remote_values` should be unscheduled.